### PR TITLE
Bumps nanoFramework.Windows.Devices.Gpio from 1.0.4 to 1.0.5

### DIFF
--- a/source/nanoFramework.Hardware.Esp32.DELIVERABLES.nuspec
+++ b/source/nanoFramework.Hardware.Esp32.DELIVERABLES.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.1.1]" />
       <dependency id="nanoFramework.Runtime.Events" version="[1.0.4]" />
-      <dependency id="nanoFramework.Windows.Devices.Gpio" version="[1.0.4]" />
+      <dependency id="nanoFramework.Windows.Devices.Gpio" version="[1.0.5]" />
     </dependencies>
   </metadata>
   <files>

--- a/source/nanoFramework.Hardware.Esp32.nuspec
+++ b/source/nanoFramework.Hardware.Esp32.nuspec
@@ -19,7 +19,7 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.1.1]" />
       <dependency id="nanoFramework.Runtime.Events" version="[1.0.4]" />
-      <dependency id="nanoFramework.Windows.Devices.Gpio" version="[1.0.4]" />
+      <dependency id="nanoFramework.Windows.Devices.Gpio" version="[1.0.5]" />
     </dependencies>
   </metadata>
   <files>

--- a/source/nanoFramework.Hardware.Esp32/nanoFramework.Hardware.Esp32.nfproj
+++ b/source/nanoFramework.Hardware.Esp32/nanoFramework.Hardware.Esp32.nfproj
@@ -51,7 +51,7 @@
     <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Runtime.Events.1.0.4\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Windows.Devices.Gpio.1.0.4\lib\nanoFramework.Windows.Devices.Gpio.dll">
+    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Windows.Devices.Gpio.1.0.5\lib\nanoFramework.Windows.Devices.Gpio.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -81,8 +81,8 @@
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.4\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.0.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Windows.Devices.Gpio.1.0.4\lib\Windows.Devices.Gpio.dll</HintPath>
+    <Reference Include="Windows.Devices.Gpio, Version=1.0.5.1, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Windows.Devices.Gpio.1.0.5\lib\Windows.Devices.Gpio.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,11 +92,11 @@
       <ProjectConfigurationsDeclaredAsItems />
     </ProjectCapabilities>
   </ProjectExtensions>
-  <Import Project="..\packages\Nerdbank.GitVersioning.3.0.4-beta\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.0.4-beta\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Nerdbank.GitVersioning.3.0.4-beta\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Nerdbank.GitVersioning.3.0.4-beta\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
 </Project>

--- a/source/nanoFramework.Hardware.Esp32/packages.config
+++ b/source/nanoFramework.Hardware.Esp32/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.1.1" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.0.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.0.4" targetFramework="netnanoframework10" />
-  <package id="Nerdbank.GitVersioning" version="3.0.4-beta" developmentDependency="true" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Windows.Devices.Gpio" version="1.0.5" targetFramework="netnanoframework10" />
+  <package id="Nerdbank.GitVersioning" version="3.0.6-beta" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.Windows.Devices.Gpio from 1.0.4 to 1.0.5

[version update]

