### PR TITLE
Add sd card pins to device configuration

### DIFF
--- a/nanoFramework.Hardware.Esp32/DeviceTypePins.cs
+++ b/nanoFramework.Hardware.Esp32/DeviceTypePins.cs
@@ -162,6 +162,23 @@ namespace nanoFramework.Hardware.Esp32
         COM3_CTS = DeviceTypes.SERIAL + (3 * ValueTypes.DeviceIndex) + 3,
 
         /// <summary>
+        /// Device function TX data for COM4 
+        /// </summary>
+        COM4_TX = DeviceTypes.SERIAL + (4 * ValueTypes.DeviceIndex) + 0,
+        /// <summary>
+        /// Device function RX data for COM4 
+        /// </summary>
+        COM4_RX = DeviceTypes.SERIAL + (4 * ValueTypes.DeviceIndex) + 1,
+        /// <summary>
+        /// Device function Request to Send(RTS) for COM4
+        /// </summary>
+        COM4_RTS = DeviceTypes.SERIAL + (4 * ValueTypes.DeviceIndex) + 2,
+        /// <summary>
+        /// Device function Clear to Send(CTS) for COM4
+        /// </summary>
+        COM4_CTS = DeviceTypes.SERIAL + (4 * ValueTypes.DeviceIndex) + 3,
+
+        /// <summary>
         /// Device function PWM1 
         /// </summary>
         PWM1 =  DeviceTypes.PWM + (1 * ValueTypes.DeviceIndex) + 0,

--- a/nanoFramework.Hardware.Esp32/DeviceTypePins.cs
+++ b/nanoFramework.Hardware.Esp32/DeviceTypePins.cs
@@ -53,6 +53,11 @@ namespace nanoFramework.Hardware.Esp32
         /// I2S Device type
         /// </summary>
         I2S = 6 * ValueTypes.DeviceType,
+
+        /// <summary>
+        /// SDMMC SD card pins
+        /// </summary>
+        SDMMC = 8 * ValueTypes.DeviceType
     };
 
     /// <summary>
@@ -366,5 +371,65 @@ namespace nanoFramework.Hardware.Esp32
         /// Used for input data typically from a microphone.
         /// </summary>
         I2S2_MDATA_IN = DeviceTypes.I2S + (2 * ValueTypes.DeviceIndex) + 4,
+
+        /// <summary>
+        /// SDMMC clock pin.
+        /// </summary>
+        SDMMC1_CLOCK = DeviceTypes.SDMMC + (1 * ValueTypes.DeviceIndex) + 0,
+
+        /// <summary>
+        /// SDMMC1 command pin
+        /// </summary>
+        SDMMC1_COMMAND = DeviceTypes.SDMMC + (1 * ValueTypes.DeviceIndex) + 1,
+
+        /// <summary>
+        /// SDMMC1 data pin D0
+        /// </summary>
+        SDMMC1_D0 = DeviceTypes.SDMMC + (1 * ValueTypes.DeviceIndex) + 2,
+
+        /// <summary>
+        /// SDMMC1 data pin D1
+        /// </summary>
+        SDMMC1_D1 = DeviceTypes.SDMMC + (1 * ValueTypes.DeviceIndex) + 3,
+
+        /// <summary>
+        /// SDMMC1 data pin D2
+        /// </summary>
+        SDMMC1_D2 = DeviceTypes.SDMMC + (1 * ValueTypes.DeviceIndex) + 4,
+
+        /// <summary>
+        /// SDMMC1 data pin D3
+        /// </summary>
+        SDMMC1_D3 = DeviceTypes.SDMMC + (1 * ValueTypes.DeviceIndex) + 5,
+
+        /// <summary>
+        /// SDMMC2 clock pin.
+        /// </summary>
+        SDMMC2_CLOCK = DeviceTypes.SDMMC + (2 * ValueTypes.DeviceIndex) + 0,
+
+        /// <summary>
+        /// SDMMC2 command pin
+        /// </summary>
+        SDMMC2_COMMAND = DeviceTypes.SDMMC + (2 * ValueTypes.DeviceIndex) + 1,
+
+        /// <summary>
+        /// SDMMC2 data pin D0
+        /// </summary>
+        SDMMC2_D0 = DeviceTypes.SDMMC + (2 * ValueTypes.DeviceIndex) + 2,
+
+        /// <summary>
+        /// SDMMC2 data pin D1
+        /// </summary>
+        SDMMC2_D1 = DeviceTypes.SDMMC + (2 * ValueTypes.DeviceIndex) + 3,
+
+        /// <summary>
+        /// SDMMC2 data pin D2
+        /// </summary>
+        SDMMC2_D2 = DeviceTypes.SDMMC + (2 * ValueTypes.DeviceIndex) + 4,
+
+        /// <summary>
+        /// SDMMC2 data pin D3
+        /// </summary>
+        SDMMC2_D3 = DeviceTypes.SDMMC + (2 * ValueTypes.DeviceIndex) + 5
     };
  }


### PR DESCRIPTION
## Description

- Adds pin definitions for SD card pins for 2 x SD card slots to allow esp32_s3  to change pins for sdcard. Called SDMMC1 & SDMMC2 as this is what's referred in Espressif IDF

- Add pin definitions for COM4 to allow testing of esp32_p4



## Motivation and Context
- Fixes nanoFramework/Home#1447

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally with updated SD card mount sample
Will test COM4 later

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
