### PR TITLE
Remove unnecessary `EventArgs` allocation in `HighResTimer`

### DIFF
--- a/nanoFramework.Hardware.Esp32/HighResTimer.cs
+++ b/nanoFramework.Hardware.Esp32/HighResTimer.cs
@@ -50,7 +50,7 @@ namespace nanoFramework.Hardware.Esp32
                 }
             }
 
-            callbacks?.Invoke(this, new EventArgs());
+            callbacks?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
There's a minor optimization in HighResTimer where we can avoid allocating a new EventArgs object every time the timer elapses. Instead, we can use EventArgs.Empty to reduce memory usage and improve performance, which is especially important in resource-constrained environments.

## Motivation and Context
- There is related [Discord thread](https://discord.com/channels/478725473862549535/1222703519547523102) on the HighResTimer issue that is crashing due to out of memory exception and one of the causes is unnecessary memory allocation during the event firing.

## How Has This Been Tested?
- Only successfully rebuild the solution without flashing to the ESP32

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
